### PR TITLE
Fix session info logging

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MMAPPR2
 Title: Mutation Mapping Analysis Pipeline for Pooled RNA-Seq
-Version: 0.98.3
+Version: 0.98.4
 Authors@R: person("First", "Last", email = "first.last@example.com", role = c("aut", "cre"))
 Maintainer: Jonathon Hill <jhill@byu.edu>
 Description: MMAPPR2 maps mutations resulting from pooled RNA-seq data from the F2

--- a/R/main.R
+++ b/R/main.R
@@ -70,10 +70,11 @@ mmappr <- function(mmapprParam) {
         mmapprData <- generateCandidates(mmapprData)
         .messageAndLog("Done", oF)
         
-        .messageAndLog("Output files generated", oF)
+        .messageAndLog("Writing output plots and tables...", oF)
         outputMmapprData(mmapprData)
+        .messageAndLog("Done", oF)
         
-        return(mmapprData)
+        mmapprData  # return for use after block
     }, 
     error = function(e) {
         .messageAndLog(paste('ERROR:', e$message), oF)


### PR DESCRIPTION
On successful runs, the tryCatch returned from the function instead. Now it will still print runtime, sessionInfo(), etc.