### PR TITLE
Drop MT name (from Ensembl) from analysis

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MMAPPR2
 Title: Mutation Mapping Analysis Pipeline for Pooled RNA-Seq
-Version: 0.98.5
+Version: 0.98.6
 Authors@R: person("First", "Last", email = "first.last@example.com", role = c("aut", "cre"))
 Maintainer: Jonathon Hill <jhill@byu.edu>
 Description: MMAPPR2 maps mutations resulting from pooled RNA-seq data from the F2

--- a/R/read_bam.R
+++ b/R/read_bam.R
@@ -134,9 +134,13 @@ readInFiles <- function(mmapprData) {
     
     chrList <- list()
     # store range for each chromosome as list item
-    for (i in suppressWarnings(GenomeInfoDb::orderSeqlevels(names(chrRanges)))) {
+    for (i in suppressWarnings(
+        GenomeInfoDb::orderSeqlevels(
+            as.character(GenomeInfoDb::seqnames(chrRanges))))) {
+        
         chrList[[toString(GenomeInfoDb::seqnames(chrRanges[i]))]] <- chrRanges[i]
     }
+
     
     return(chrList)
 })}

--- a/R/read_bam.R
+++ b/R/read_bam.R
@@ -130,6 +130,7 @@ readInFiles <- function(mmapprData) {
     #cut to standard chromosomes
     chrRanges <- GenomeInfoDb::keepStandardChromosomes(chrRanges, pruning.mode='coarse')
     chrRanges <- GenomeInfoDb::dropSeqlevels(chrRanges, 'chrM', pruning.mode='coarse')
+    chrRanges <- GenomeInfoDb::dropSeqlevels(chrRanges, 'MT', pruning.mode='coarse')
     
     chrList <- list()
     # store range for each chromosome as list item

--- a/tests/testthat/test_read_bam.R
+++ b/tests/testthat/test_read_bam.R
@@ -36,6 +36,27 @@ test_that("correct ranges are being read", {
     rm(chrList)
 })
 
+test_that('chrM and MT are dropped and sequences are reordered', {
+    skip_if_not_installed('mockery')
+    ucscNames <- c('chr1', 'chr2', 'chrM')
+    ensemblNames <- c('1', '2', 'MT')
+    mockGR <- mockery::mock(GenomicRanges::GRanges(ucscNames,
+                                                   IRanges::IRanges(0, 1)
+                            ),
+                            GenomicRanges::GRanges(ensemblNames,
+                                                   IRanges::IRanges(0, 1)
+                            )
+    )
+    mockery::stub(.getFileReadChrList, 'as', mockGR)
+    chrList <- .getFileReadChrList(mmapprData)
+    expect_equal(names(chrList), c('chr1', 'chr2'))
+    
+    chrList <- .getFileReadChrList(mmapprData)
+    expect_equal(names(chrList), c('1', '2'))
+    
+    mockery::expect_called(mockGR, 2)
+})
+
 
 test_that("single chromosome is read correctly", {
     skip_if_not_installed('mockery')


### PR DESCRIPTION
We still need unit tests for this
Closes #73 